### PR TITLE
Fixed mintupload so that it now starts at runtime

### DIFF
--- a/etc/xdg/autostart/mintupload.desktop
+++ b/etc/xdg/autostart/mintupload.desktop
@@ -7,4 +7,4 @@ Exec=/usr/lib/linuxmint/mintUpload/launch-file-uploader.py
 Terminal=false
 Type=Application
 Categories=
-OnlyShowIn=GNOME;XFCE;KDE;
+OnlyShowIn=GNOME;XFCE;KDE;MATE;


### PR DESCRIPTION
"MATE;" was missing from "OnlyShowIn"
