### PR TITLE
Don't special case the systray icon in Mate

### DIFF
--- a/usr/lib/linuxmint/mintupload/file-uploader.py
+++ b/usr/lib/linuxmint/mintupload/file-uploader.py
@@ -29,13 +29,6 @@ class MainClass:
         self.status_icon.set_status(AppIndicator.IndicatorStatus.ACTIVE)
         self.status_icon.set_icon(SYSTRAY_ICON)
         self.status_icon.set_title(_("Upload services"))
-
-        try:
-            if os.environ["XDG_CURRENT_DESKTOP"].lower() == "mate":
-                self.status_icon.set_icon("up")
-        except Exception, detail:
-            print detail
-
         self.services = None
 
         self.build_services_menu()


### PR DESCRIPTION
Not sure the reason this was being done but it no longer seems needed. Just use
the correct tray icon instead.